### PR TITLE
Update Setup.yaml with new lambda managed arn changes

### DIFF
--- a/Setup.yaml
+++ b/Setup.yaml
@@ -69,7 +69,7 @@ Resources:
             Action:
               - sts:AssumeRole
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/AWSLambdaFullAccess
+        - arn:aws:iam::aws:policy/AWSLambda_FullAccess
         - arn:aws:iam::aws:policy/AWSCloudFormationFullAccess
         - arn:aws:iam::aws:policy/AWSCodePipelineFullAccess
       Path: /


### PR DESCRIPTION
AWSLambda_FullAccess – Grants full access to Lambda actions and other AWS services used to develop and maintain Lambda resources. This policy was created by scoping down the previous policy AWSLambdaFullAccess.

https://docs.aws.amazon.com/lambda/latest/dg/access-control-identity-based.html